### PR TITLE
Fix #8: Navigation drawer is not scroll-able

### DIFF
--- a/src/components/core/Drawer.vue
+++ b/src/components/core/Drawer.vue
@@ -11,6 +11,7 @@
   >
     <v-img
       :src="image"
+      :gradient="sidebarOverlayGradiant"
       height="100%"
     >
       <v-layout
@@ -136,6 +137,9 @@ export default {
     },
     items () {
       return this.$t('Layout.View.items')
+    },
+    sidebarOverlayGradiant () {
+      return `${this.$store.state.app.sidebarBackgroundColor}, ${this.$store.state.app.sidebarBackgroundColor}`
     }
   },
   mounted () {
@@ -178,6 +182,10 @@ export default {
       margin-bottom: 30px !important;
       padding-left: 15px;
       padding-right: 15px;
+    }
+
+    div.v-responsive.v-image > div.v-responsive__content {
+      overflow-y: auto;
     }
   }
 </style>

--- a/src/store/modules/app/state.js
+++ b/src/store/modules/app/state.js
@@ -1,5 +1,6 @@
 export default {
   drawer: null,
   color: 'success',
-  image: 'https://demos.creative-tim.com/vue-material-dashboard/img/sidebar-2.32103624.jpg'
+  image: 'https://demos.creative-tim.com/vue-material-dashboard/img/sidebar-2.32103624.jpg',
+  sidebarBackgroundColor: 'rgba(27, 27, 27, 0.74)'
 }

--- a/src/styles/material-dashboard/_sidebar.scss
+++ b/src/styles/material-dashboard/_sidebar.scss
@@ -2,7 +2,6 @@
   @include shadow-big();
 
   .v-list {
-    background: $sidebar-bg;
     padding: 0;
 
     .v-list-item {

--- a/src/styles/material-dashboard/_variables.scss
+++ b/src/styles/material-dashboard/_variables.scss
@@ -47,9 +47,6 @@ $divider-width:                     calc(100% - 30px) !default;
 $divider-margins:                   -1px !default;
 $divider-border:                    1px solid #eee;
 
-// Sidebar Background
-$sidebar-bg:                        rgba(27, 27, 27, .74) !default;
-
 // Font size
 $font-size-mini:                    9px !default;
 $font-size-small:                   12px !default;


### PR DESCRIPTION
Hi,

I've solved issue #8 which makes drawer scroll-able by simply adding a `overflow` property to navigation list and migrating `$sidebar-bg` to be used as `gradiant` prop of sidebar [v-img](https://vuetifyjs.com/en/components/images).

Cheers 🍻