### PR TITLE
[Bug Fix] pass through color variable from store

### DIFF
--- a/src/components/core/Drawer.vue
+++ b/src/components/core/Drawer.vue
@@ -125,7 +125,7 @@
     }),
 
     computed: {
-      ...mapState('app', ['image', 'color']),
+      ...mapState('app', ['image']),
       inputValue: {
         get () {
           return this.$store.state.app.drawer


### PR DESCRIPTION
Hi,

I've just updated to the latest version of the theme (thanks!) and of Vuetify. In the process, realized that the `color` Vuex state was not being used in the `Drawer` component any longer?

Cheers
Bruno